### PR TITLE
Fixed package name typo

### DIFF
--- a/android/src/main/java/com/salesforce/msdk/reactnative/SalesforceBasePackage.java
+++ b/android/src/main/java/com/salesforce/msdk/reactnative/SalesforceBasePackage.java
@@ -23,7 +23,7 @@
  * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  */
-package com.salesforce.masdk.reactnative;
+package com.salesforce.msdk.reactnative;
 
 import com.facebook.react.ReactPackage;
 import com.facebook.react.bridge.JavaScriptModule;


### PR DESCRIPTION
Te package name in the SalesforceBasePackage.java has a typo, which creates a compilation error